### PR TITLE
detailed logging, version for user-testing w/ limited controls, loade…

### DIFF
--- a/apps/readingcontrols/README.md
+++ b/apps/readingcontrols/README.md
@@ -53,7 +53,7 @@ See [DEVELOPERS.md](./DEVELOPERS.md)
 
 ### 2022/02/11
 - expanded logging for recipe manipulation
-- optionally turned off some controls
+- optionally turned off some controls in the app at `/user-testing`
 - option to load a different default set of recipes
 
 ### 2021/11/19

--- a/apps/readingcontrols/package-lock.json
+++ b/apps/readingcontrols/package-lock.json
@@ -5270,6 +5270,15 @@
       "integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/bluebird/-/bluebird-3.7.2.tgz",
@@ -7985,6 +7994,12 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.1.0",
       "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/filesize/-/filesize-6.1.0.tgz",
@@ -8559,6 +8574,14 @@
       "version": "1.1.0",
       "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4="
+    },
+    "history": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
+      "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -10917,6 +10940,12 @@
       "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
+    },
     "nanoid": {
       "version": "3.1.23",
       "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/nanoid/-/nanoid-3.1.23.tgz",
@@ -13139,6 +13168,23 @@
       "version": "0.8.3",
       "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha1-ch1GV2ctQAxePHXQY8SoX7LV1o8="
+    },
+    "react-router": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
+      "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
+      "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.2.1"
+      }
     },
     "react-scripts": {
       "version": "4.0.3",
@@ -15814,7 +15860,11 @@
           "version": "1.2.13",
           "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -16392,7 +16442,11 @@
           "version": "1.2.13",
           "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/apps/readingcontrols/package.json
+++ b/apps/readingcontrols/package.json
@@ -16,6 +16,7 @@
     "react": "^17.0.2",
     "react-color": "^2.19.3",
     "react-dom": "^17.0.2",
+    "react-router-dom": "^6.2.1",
     "react-scripts": "4.0.3",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"

--- a/apps/readingcontrols/src/components/Controls.tsx
+++ b/apps/readingcontrols/src/components/Controls.tsx
@@ -27,7 +27,7 @@ import SliderControl from "./SliderControl";
 import RecipeBox from "./RecipeBox";
 import {FontPicker} from "./FontPicker";
 
-const Controls = () => {
+const Controls = (props: { useAdvancedSettings: boolean; }) => {
   const [showFullFileChooser, setShowFullFileChooser] = useState(false);
   const controls = useControls();
   const controlSetter = useControlSetter();
@@ -67,49 +67,56 @@ const Controls = () => {
           <Item key="justify">Justify</Item>
         </Picker>
         <SliderControl controlName="columnWidth" label="Column width" minValue={2} maxValue={8} step={0.2}/>
-        <Switch isSelected={controls.darkMode} onChange={(val) => {
-          controlSetter('darkMode', 'switch', val);
-        }}>Dark mode</Switch>
-        <ColorPalette label="Color theme" currentColor={{text: controls.foregroundColor, back: controls.backgroundColor}}
-                      setColor={(newText: string, newBack: string) => {
-                       controlSetter('foregroundColor', 'color', newText);
-                       controlSetter('backgroundColor', 'color', newBack);
-                     }} darkMode={controls.darkMode}/>
-        <SliderControl controlName="backgroundSaturation" label="Contrast" minValue={0} maxValue={100} step={1}
-                       isDisabled={controls.backgroundColor === '#FFFFFF'}/>
-        <div><Switch isSelected={controls.showRuler} onChange={(val) => {
-          controlSetter('showRuler', 'switch', val);
-        }}>Show reading ruler</Switch>
-          <Switch isSelected={controls.rulerUnderline} isHidden={!controls.showRuler} onChange={(val) => {
-            controlSetter('rulerUnderline', 'switch', val);
-          }}>Underline ruler</Switch></div>
-        <View paddingStart="25px" isHidden={!controls.showRuler} width="300px">
-          <Switch isSelected={controls.rulerInvert} isHidden={controls.rulerUnderline} onChange={(val) => {
-            controlSetter('rulerInvert', 'switch', val);
-          }}>Invert ruler (gray bar)</Switch>
-          <Switch isSelected={controls.rulerSnapToLine} isHidden={controls.rulerFollowsMouse} onChange={(val) => {
-            controlSetter('rulerSnapToLine', 'switch', val);
-          }}>Ruler aligns with text lines</Switch>
-          <Switch isSelected={controls.rulerFollowsMouse} onChange={(val) => {
-            controlSetter('rulerFollowsMouse', 'switch', val);
-          }}>Ruler position follows mouse</Switch>
-          <Switch isSelected={controls.rulerDisableMouse} isHidden={controls.rulerFollowsMouse} onChange={(val) => {
-            controlSetter('rulerDisableMouse', 'switch', val);
-          }}>Hide mouse over text</Switch>
-          <View isHidden={controls.rulerUnderline}>
-            <SliderControl controlName="rulerHeight" label="Ruler height" minValue={1} maxValue={10} step={0.1}/>
-            <SliderControl controlName="rulerOpacity" label="Ruler opacity" minValue={0} maxValue={1} step={0.01}/>
-            <SliderControl controlName="rulerTransitionHeight" label="Ruler fuzzy border" minValue={0} maxValue={10}
-                           step={1}/>
+        {props.useAdvancedSettings && (
+          <div>
+          <Switch isSelected={controls.darkMode} onChange={(val) => {
+            controlSetter('darkMode', 'switch', val);
+          }}>Dark mode</Switch>
+          <ColorPalette label="Color theme" currentColor={{text: controls.foregroundColor, back: controls.backgroundColor}}
+                        setColor={(newText: string, newBack: string) => {
+                        controlSetter('foregroundColor', 'color', newText);
+                        controlSetter('backgroundColor', 'color', newBack);
+                      }} darkMode={controls.darkMode}/>
+          <SliderControl controlName="backgroundSaturation" label="Contrast" minValue={0} maxValue={100} step={1}
+                        isDisabled={controls.backgroundColor === '#FFFFFF'}/>
+          <div><Switch isSelected={controls.showRuler} onChange={(val) => {
+            controlSetter('showRuler', 'switch', val);
+          }}>Show reading ruler</Switch>
+            <Switch isSelected={controls.rulerUnderline} isHidden={!controls.showRuler} onChange={(val) => {
+              controlSetter('rulerUnderline', 'switch', val);
+            }}>Underline ruler</Switch></div>
+          <View paddingStart="25px" isHidden={!controls.showRuler} width="300px">
+            <Switch isSelected={controls.rulerInvert} isHidden={controls.rulerUnderline} onChange={(val) => {
+              controlSetter('rulerInvert', 'switch', val);
+            }}>Invert ruler (gray bar)</Switch>
+            <Switch isSelected={controls.rulerSnapToLine} isHidden={controls.rulerFollowsMouse} onChange={(val) => {
+              controlSetter('rulerSnapToLine', 'switch', val);
+            }}>Ruler aligns with text lines</Switch>
+            <Switch isSelected={controls.rulerFollowsMouse} onChange={(val) => {
+              controlSetter('rulerFollowsMouse', 'switch', val);
+            }}>Ruler position follows mouse</Switch>
+            <Switch isSelected={controls.rulerDisableMouse} isHidden={controls.rulerFollowsMouse} onChange={(val) => {
+              controlSetter('rulerDisableMouse', 'switch', val);
+            }}>Hide mouse over text</Switch>
+            <View isHidden={controls.rulerUnderline}>
+              <SliderControl controlName="rulerHeight" label="Ruler height" minValue={1} maxValue={10} step={0.1}/>
+              <SliderControl controlName="rulerOpacity" label="Ruler opacity" minValue={0} maxValue={1} step={0.01}/>
+              <SliderControl controlName="rulerTransitionHeight" label="Ruler fuzzy border" minValue={0} maxValue={10}
+                            step={1}/>
+            </View>
           </View>
-
-        </View>
+        </div>
+        )}
         <div className={styles.ButtonRow}>
           <ActionButton onPress={downloadAllLogRecords}>Download log</ActionButton>
           <ActionButton onPress={clearLogRecords} isHidden={true}>Clear log</ActionButton>
           <ActionButton onPress={resetAllControls}>Reset all controls</ActionButton>
         </div>
-        <RecipeBox/>
+              {props.useAdvancedSettings ? (
+        <RecipeBox defaultRecipes/>
+      ):(
+        <RecipeBox defaultRecipes={false}/>
+      )}
       </div>
     </div>
   );

--- a/apps/readingcontrols/src/components/Main.tsx
+++ b/apps/readingcontrols/src/components/Main.tsx
@@ -19,6 +19,8 @@ import Controls from "./Controls";
 import ReadingView from "./ReadingView";
 import {createContext, useContext, useEffect, useReducer} from "react";
 import {addLogRecord, clearLogRecords, ControlValue} from "./logging";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+
 
 export interface IControls {
   html: string,
@@ -129,8 +131,16 @@ const Main = (props: {
     <ControlsContext.Provider value={controlsState}>
       <ControlSetterContext.Provider value={controlSetter}>
         <div className={styles.Main}>
-          <Controls/>
-          <ReadingView/>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<Controls useAdvancedSettings />} />
+              <Route
+                path="/user-testing"
+                element={<Controls useAdvancedSettings={false} />}
+              />
+            </Routes>
+          </BrowserRouter>
+          <ReadingView />
         </div>
       </ControlSetterContext.Provider>
     </ControlsContext.Provider>

--- a/apps/readingcontrols/src/components/RecipeBox.tsx
+++ b/apps/readingcontrols/src/components/RecipeBox.tsx
@@ -26,6 +26,8 @@ import {addLogRecord, ControlValue} from "./logging";
 import {downloadFile, randomizeArray} from "../utils";
 import RecipeAdmin from "./RecipeAdmin";
 import defaultClusterRecipes from "../data/defaultClusterRecipes.json";
+import customClusterRecipes from "../data/designerIteration20220210.json";
+
 
 export type IRecipeData = {
   name: string | null;
@@ -42,7 +44,7 @@ type IRecipeAdminContext = {
 const RecipeAdminContext = createContext<IRecipeAdminContext>(undefined!);
 export const useRecipeAdminContext = () => useContext(RecipeAdminContext);
 
-const RecipeBox = () => {
+const RecipeBox = (props:{defaultRecipes: boolean}) => {
   const [allRecipes, setAllRecipes] = useState<Map<number, IRecipeData>>(new Map());
   const [adminDialogOpen, setAdminDialogOpen] = useState(false);
   const [showAdd, setShowAdd] = useState(true);
@@ -64,7 +66,7 @@ const RecipeBox = () => {
   function logRecipeCreation(recipeData: IRecipeData) {
     for (const [controlName, value] of Object.entries(recipeData.controlValues)) {
       if (controlName === 'html') continue;
-      if (value === controlsInitialState[controlName]) continue;
+      // if (value === controlsInitialState[controlName]) continue;
       addLogRecord(controlName, 'recipeCreate: ' + recipeData.name, 'na', value as ControlValue);
     }
   }
@@ -128,7 +130,11 @@ const RecipeBox = () => {
   // load the default recipes at startup
   useEffect(() => {
     setTimeout(() => {
-      loadAllRecipes(randomizeArray(defaultClusterRecipes));
+      if (props.defaultRecipes) {
+        loadAllRecipes(randomizeArray(defaultClusterRecipes));
+      } else {
+        loadAllRecipes(randomizeArray(customClusterRecipes));
+      }
     }, 500); // HACK: this has to run after Main has cleared the log records, so we can log the loaded recipes,
     // but I don't see a good way to interlock
   }, [loadAllRecipes]);

--- a/apps/readingcontrols/src/data/designerIteration20220210.json
+++ b/apps/readingcontrols/src/data/designerIteration20220210.json
@@ -1,0 +1,128 @@
+[
+    {
+        "name": "C13766143R",
+        "controlValues": {
+            "characterSpacing": 0,
+            "columnWidth": 6,
+            "darkMode": false,
+            "fontSize": 20,
+            "lineHeight": 1.8,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "wordSpacing": 0,
+            "fontName": "Arial"
+        }
+    },
+    {
+        "name": "C23703015AA",
+        "controlValues": {
+            "characterSpacing": 0,
+            "columnWidth": 6,
+            "darkMode": false,
+            "fontSize": 15,
+            "lineHeight": 1.5,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 1.5,
+            "wordSpacing": 0,
+            "fontName": "Times"
+        }
+    },
+    {
+        "name": "C33748376F",
+        "controlValues": {
+            "characterSpacing": 0,
+            "columnWidth": 6,
+            "darkMode": false,
+            "fontSize": 17,
+            "lineHeight": 1.8,
+            "paragraphIndent": 0.2,
+            "paragraphSpacing": 1.5,
+            "wordSpacing": 0.2,
+            "fontName": "Merriweather"
+        }
+    },
+    {
+        "name": "C43703015A",
+        "controlValues": {
+            "characterSpacing": 0,
+            "columnWidth": 6,
+            "darkMode": false,
+            "fontSize": 20,
+            "lineHeight": 1.8,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "wordSpacing": 0,
+            "fontName": "Times"
+        }
+    },
+    {
+        "name": "C63766143Q",
+        "controlValues": {
+            "characterSpacing": 0,
+            "columnWidth": 6,
+            "darkMode": false,
+            "fontSize": 18,
+            "lineHeight": 1.4,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 1.5,
+            "wordSpacing": 0.1,
+            "fontName": "Arial"
+        }
+    },
+    {
+        "name": "C73766143AB",
+        "controlValues": {
+            "characterSpacing": 0,
+            "columnWidth": 6,
+            "darkMode": false,
+            "fontSize": 24,
+            "lineHeight": 1.5,
+            "paragraphIndent": 0.35,
+            "paragraphSpacing": 1.5,
+            "wordSpacing": 0,
+            "fontName": "SourceSerifPro"
+        }
+    },
+    {
+        "name": "C93748376AE",
+        "controlValues": {
+            "characterSpacing": 0,
+            "columnWidth": 6,
+            "darkMode": false,
+            "fontSize": 17,
+            "lineHeight": 1.5,
+            "paragraphIndent": 0.4,
+            "paragraphSpacing": 2,
+            "wordSpacing": 0.2,
+            "fontName": "Times"
+        }
+    },
+    {
+        "name": "C103703015AN",
+        "controlValues": {
+            "characterSpacing": 0,
+            "columnWidth": 6,
+            "darkMode": false,
+            "fontSize": 17,
+            "lineHeight": 1.5,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "wordSpacing": 0,
+            "fontName": "Arial"
+        }
+    },
+    {
+        "name": "C113703015AU",
+        "controlValues": {
+            "characterSpacing": 0,
+            "columnWidth": 6,
+            "darkMode": false,
+            "fontSize": 22,
+            "lineHeight": 1.5,
+            "paragraphIndent": 0,
+            "paragraphSpacing": 0,
+            "wordSpacing": 0,
+            "fontName": "Arial"
+        }
+    }
+]


### PR DESCRIPTION
I made several changes in preparation for running the new studies on the usertesting.com. I’m not sure if all of them are suitable for the internal version we have.

In the /user-testing page:

- Took out the reading controls we don’t want readers to consider
- Added new cluster experiences that we wish to use as default starting points

Globally:

Added more detailed to the log
![Screen Recording 2022-02-11 at 11 23 23 AM (1)](https://user-images.githubusercontent.com/22042967/153791635-8657631d-be71-47e6-9ea0-0795fdd048f2.gif)

